### PR TITLE
[haxcms-nodejs] Fix app-store auth regression + standardize system API path

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1650,7 +1650,17 @@ function normalizeSiteApiSecurityPolicy(securityConfig = null) {
       return 'public';
     }
     if (Object.prototype.hasOwnProperty.call(requirement, 'siteTokenHeader')) {
-      return 'authenticated-site';
+      // siteTokenHeader paired with bearerAuth (in the same requirement) is
+      // 'authenticated-site' (bearer JWT + site token, e.g. provider-search,
+      // site API mutations). siteTokenHeader alone is 'site-token-only' —
+      // the site token is validated against the server-side active user by
+      // the handler (e.g. generateAppStore), no bearer JWT required. This
+      // mirrors the original handler-validated behavior and avoids requiring
+      // a bearer JWT the front-end appStore fetch does not send.
+      if (Object.prototype.hasOwnProperty.call(requirement, 'bearerAuth')) {
+        return 'authenticated-site';
+      }
+      return 'site-token-only';
     }
     if (Object.prototype.hasOwnProperty.call(requirement, 'userTokenHeader')) {
       requiresUserToken = true;

--- a/src/systemRoutes/v1/routes/connectionSettings.js
+++ b/src/systemRoutes/v1/routes/connectionSettings.js
@@ -142,20 +142,24 @@ async function connectionSettings(req, res) {
   res.setHeader('Expires', '0');
   res.setHeader('Surrogate-Control', 'no-store');
   res.setHeader('Content-Type', 'application/javascript');
-  const isDashboardRequest = (
-    HAXCMS &&
-    HAXCMS.operatingContext !== 'single' &&
-    req.headers &&
-    req.headers.referer &&
-    !req.headers.referer.includes(`/${HAXCMS.sitesDirectory}/`)
-  );
-  // default to relative API paths so calls in site context resolve correctly
-  // and mirror PHP behavior for appStore-generated endpoint paths.
-  let baseAPIPath = HAXCMS.systemRequestBase;
-  // in non-root installs, preserve basePath for site-context API routing.
-  if (!isDashboardRequest && HAXCMS.basePath && HAXCMS.basePath !== '/') {
-    baseAPIPath = `${HAXCMS.basePath}${HAXCMS.systemRequestBase}`;
+  // System API base path is always absolute (root-level), mirroring PHP
+  // (HAXCMS.php appJWTConnectionSettings forces a leading slash). System
+  // routes are not site-scoped; both backends serve them at
+  // /system/api/v1/ so calls resolve identically whether the page is a
+  // site context (/_sites/<name>/) or the system dashboard. A relative
+  // path would resolve against the current page URL and produce a
+  // site-scoped system endpoint (/_sites/<name>/system/api/v1/...) which
+  // works on Node but is not standardized with PHP.
+  let systemNormalizedBasePath = String(HAXCMS.basePath || '/');
+  if (systemNormalizedBasePath.charAt(0) !== '/') {
+    systemNormalizedBasePath = '/' + systemNormalizedBasePath;
   }
+  if (
+    systemNormalizedBasePath.charAt(systemNormalizedBasePath.length - 1) !== '/'
+  ) {
+    systemNormalizedBasePath += '/';
+  }
+  let baseAPIPath = `${systemNormalizedBasePath}${HAXCMS.systemRequestBase}`;
   var sitename = '';
   // name parsed from a multisite site-context URL (/_sites/<name>/...).
   // tracked separately because it must drive the site API base path, whereas


### PR DESCRIPTION
## Summary

Follow-up to merged PR #20. Two regression fixes noticed during post-merge testing of the app-store endpoint.

## Changes

**Standardize system API path in connection-settings (parity with PHP)**
- `connectionSettings.js`: the system API base path is now always absolute (`/{basePath}system/api/`), mirroring PHP (`HAXCMS.php` `appJWTConnectionSettings` forces a leading slash). Previously Node emitted a relative `systemRequestBase` which the browser resolved site-scoped (`/_sites/<name>/system/api/v1/...`) when called from a site context. That worked on Node (which registers site-scoped system routes) but diverged from PHP and was not standardized.

**Restore app-store site-token-only auth stance (fix regression)**
- `app.js` `normalizeSiteApiSecurityPolicy`: now distinguishes `siteTokenHeader`-only (`site-token-only`) from `bearerAuth + siteTokenHeader` (`authenticated-site`). The app-store GET declares `siteTokenHeader` alone, so it maps to `site-token-only` — the handler (`generateAppStore.js`) validates the site token against the server-side active user, no bearer JWT required.
- The conformance work in #20 mapped `siteTokenHeader` → `authenticated-site` unconditionally, which required a bearer-derived userName at the router (`enforceSystemApiSiteTokenPolicy`). The front-end appStore fetch sends the site token but not a bearer JWT, so the call was rejected (403).
- `provider-search` (`bearerAuth + siteTokenHeader`) stays `authenticated-site` and is unaffected. No site-spec routes declare `siteTokenHeader`-only, so the site API is unaffected.

## Validation
- `node --check` on both changed files → OK
- Surgical: app-store GET is the only route in either spec declaring `siteTokenHeader` without `bearerAuth`

## Related
- Predecessor: #20
- Conversation: https://app.warp.dev/conversation/f763bd0e-8f51-413f-bf9b-20eac83f721b

Co-Authored-By: Oz <oz-agent@warp.dev>